### PR TITLE
Add GitHub community standards files

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,43 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others’ private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders at Admin@dinopitstudios-llc.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing to DinoAir
+
+Thank you for your interest in contributing to DinoAir! We welcome contributions from everyone.
+
+## How to Contribute
+
+1. **Fork the repository**
+2. **Create your feature branch** (`git checkout -b feature/your-feature`)
+3. **Commit your changes** (`git commit -am 'Add new feature'`)
+4. **Push to the branch** (`git push origin feature/your-feature`)
+5. **Open a pull request** with a clear description of your changes
+
+## Areas for Contribution
+
+- 🐛 Bug fixes
+- ✨ New features
+- 📚 Documentation
+- 🧪 Tests
+- 🎨 UI/UX improvements
+
+## Code Style
+
+- Use TypeScript for frontend code
+- Use Python 3.11+ for backend code
+- Follow ESLint and Prettier rules for JavaScript/TypeScript
+- Use conventional commit messages
+
+## Pull Request Process
+
+- Ensure your branch is up to date with `master`
+- Add tests for new features or bug fixes
+- Ensure all tests pass (`npm test` or `pytest`)
+- Fill out the pull request template
+
+## Reporting Bugs
+
+Please use the "Bug report" issue template and provide as much detail as possible.
+
+## Security Issues
+
+Please do not open public issues for security vulnerabilities. Instead, email Admin@dinopitstudios-llc.com.
+
+## Community
+
+- [Discord](https://discord.gg/dinoair)
+- [Documentation](docs/)
+
+Thank you for helping make DinoAir better!

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a report to help us improve DinoAir
+title: "[Bug] "
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment (please complete the following information):**
+ - OS: [e.g. Windows, Ubuntu, macOS]
+ - Browser [e.g. Chrome, Firefox]
+ - Version [e.g. 1.0.0]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for DinoAir
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,14 @@
+---
+name: Question
+about: Ask a question about DinoAir
+title: "[Question] "
+labels: question
+assignees: ''
+
+---
+
+**What is your question?**
+A clear and concise question.
+
+**Additional context**
+Add any other context or details here.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Supported Versions
+
+We release security updates for the latest major version of DinoAir.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please email Admin@dinopitstudios-llc.com. Do **not** create a public issue.
+
+We will respond as quickly as possible and coordinate a fix.
+
+## Security Best Practices
+
+- Always use strong, unique API keys and secrets
+- Keep your dependencies up to date
+- Enable HTTPS in production
+- Monitor for suspicious activity
+
+Thank you for helping keep DinoAir secure!

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,10 @@
+# Support
+
+If you need help with DinoAir:
+
+- 📖 Check the [Documentation](docs/)
+- 🐛 Report issues on [GitHub Issues](https://github.com/Dinopit/DinoAirPublic/issues)
+- 💬 Join our [Discord](https://discord.gg/dinoair)
+- 📧 Email support: Admin@dinopitstudios-llc.com
+
+For security issues, please see [SECURITY.md](SECURITY.md).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+# Pull Request
+
+Thank you for your contribution to DinoAir!
+
+## Checklist
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+
+## Description
+
+Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.
+
+Fixes #

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Dinopit Studios LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
- Add CODE_OF_CONDUCT.md with Contributor Covenant
- Add CONTRIBUTING.md with contribution guidelines
- Add SECURITY.md with vulnerability reporting process
- Add LICENSE file with MIT license
- Add issue templates for bug reports, feature requests, and questions
- Add pull request template with checklist
- Add SUPPORT.md with community resources

These files ensure full compliance with GitHub Community Standards.